### PR TITLE
fixed use of depricated attributes

### DIFF
--- a/src/auditlog/relations.py
+++ b/src/auditlog/relations.py
@@ -24,7 +24,7 @@ class LogRelationsRegistry(dict):
                 # _meta.get_field_by_name
                 field = parent._meta.get_field(part)
                 if isinstance(field, RelatedField):
-                    parent = field.related.parent_model
+                    parent = field.rel.model
                 else:
                     raise ValueError("Error on '%s': '%s' has no relation '%s'" % (model, parent, part))
 


### PR DESCRIPTION
The Field.related attribute was depricated and the object it points to was
changed in Django 1.8 [1]. This fixes the related model lookup code to work
with Django 1.9.

[1] https://docs.djangoproject.com/en/1.9/releases/1.8/#model-field-related